### PR TITLE
fastd: Use MTU 1280 for new fastd

### DIFF
--- a/roles/fastd/defaults/main.yml
+++ b/roles/fastd/defaults/main.yml
@@ -11,7 +11,7 @@ fastd_anonymous: true
 
 fastd_interface: vpn-{{ site_code }}
 fastd_port: 50000
-fastd_mtu: 1406
+fastd_mtu: 1280
 
 fastd_backbone_interface: vpn-{{ site_code }}-bbone
 fastd_backbone_port: 50001


### PR DESCRIPTION
Most other communities seem to use this value, and because Path MTU discovery seems to be severely broken in most parts of the internet (e.g. Hetzner seems to block incoming notifications of too large packets), having a value too large may result in massive packet loss.

Better safe than sorry, and because this needs a site.conf change better change this now than later.
