### PR TITLE
add very basic "downloadsite" role, for serving downloads.bremen.freifunk.net

### DIFF
--- a/playbooks/webserver.yml
+++ b/playbooks/webserver.yml
@@ -10,3 +10,4 @@
   - apache
   - gatemon
   - website
+  - downloadsite

--- a/roles/downloadsite/README.md
+++ b/roles/downloadsite/README.md
@@ -1,0 +1,18 @@
+downloadsite
+=========================
+
+Set up webserver for download site of Freifunk Bremen
+
+
+Usage
+-------------------------
+
+    - hosts: servers
+      roles:
+         - downloadsite
+
+
+License
+-------------------------
+
+GPLv3

--- a/roles/downloadsite/defaults/main.yml
+++ b/roles/downloadsite/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+downloads_email: 'info@bremen.freifunk.net'
+downloads_user: 'ffhb-downloads'
+downloads_group: 'ffhb-downloads'
+downloads_domain: 'downloads.bremen.freifunk.net'

--- a/roles/downloadsite/meta/main.yml
+++ b/roles/downloadsite/meta/main.yml
@@ -1,0 +1,9 @@
+---
+dependencies:
+  - zsh
+  - apache
+galaxy_info:
+  platforms:
+    - name: Debian
+      versions:
+        - jessie

--- a/roles/downloadsite/tasks/main.yaml
+++ b/roles/downloadsite/tasks/main.yaml
@@ -15,8 +15,7 @@
 - name: Generate self-signed SSL certificate
   command: openssl req -new -x509 -nodes -out /etc/ssl/certs/{{ downloads_domain }}.pem -keyout /etc/ssl/private/{{ downloads_domain }}.key -days 365 -subj "/CN={{ downloads_domain }}"
   args:
-    creates: /etc/ssl/certs/{{ downloads_domain }}.pem
-    creates: /etc/ssl/private/{{ downloads_domain }}.key
+    creates: "/etc/ssl/*/{{ downloads_domain }}.*"
 
 - name: Install Apache site config (common part)
   template: src=ffhb-downloads-common.conf dest=/etc/apache2/ mode=644

--- a/roles/downloadsite/tasks/main.yaml
+++ b/roles/downloadsite/tasks/main.yaml
@@ -1,0 +1,33 @@
+---
+- name: Add user
+  user: name={{ downloads_user }} home=/home/{{ downloads_user }} shell=/bin/zsh
+
+- name: Create needed folder structure
+  file: path=/var/www/{{ downloads_user }}/domains/{{ downloads_domain }}{{ item }} state=directory recurse=yes owner={{ downloads_user }} group={{ downloads_group }} mode=0755
+  with_items:
+  - /
+  - /data/nodes
+  - /firmware/all
+  - /opkg/modules
+  - /video
+
+# TODO: this should be replaced by some actually signed certificate:
+- name: Generate self-signed SSL certificate
+  command: openssl req -new -x509 -nodes -out /etc/ssl/certs/{{ downloads_domain }}.pem -keyout /etc/ssl/private/{{ downloads_domain }}.key -days 365 -subj "/CN={{ downloads_domain }}"
+  args:
+    creates: /etc/ssl/certs/{{ downloads_domain }}.pem
+    creates: /etc/ssl/private/{{ downloads_domain }}.key
+
+- name: Install Apache site config (common part)
+  template: src=ffhb-downloads-common.conf dest=/etc/apache2/ mode=644
+  notify: restart apache
+
+- name: Install Apache site config
+  template: src=ffhb-downloads.conf dest=/etc/apache2/sites-available/ mode=644
+  notify: restart apache
+
+- name: Enable Apache site config
+  command: a2ensite ffhb-downloads
+  args:
+    creates: /etc/apache2/sites-enabled/ffhb-downloads.conf
+  notify: restart apache

--- a/roles/downloadsite/templates/ffhb-downloads-common.conf
+++ b/roles/downloadsite/templates/ffhb-downloads-common.conf
@@ -1,0 +1,5 @@
+# VirtualHost configuration options common to both HTTP and HTTPS sites:
+
+ServerName {{ downloads_domain }}
+ServerAdmin {{ downloads_email }}
+DocumentRoot /var/www/{{ downloads_user }}/domains/{{ downloads_domain }}/

--- a/roles/downloadsite/templates/ffhb-downloads-common.conf
+++ b/roles/downloadsite/templates/ffhb-downloads-common.conf
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+
 # VirtualHost configuration options common to both HTTP and HTTPS sites:
 
 ServerName {{ downloads_domain }}

--- a/roles/downloadsite/templates/ffhb-downloads.conf
+++ b/roles/downloadsite/templates/ffhb-downloads.conf
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+
 <Directory /var/www/{{ downloads_user }}/domains/{{ downloads_domain }}/>
   AllowOverride None
   Options +Indexes

--- a/roles/downloadsite/templates/ffhb-downloads.conf
+++ b/roles/downloadsite/templates/ffhb-downloads.conf
@@ -1,0 +1,17 @@
+<Directory /var/www/{{ downloads_user }}/domains/{{ downloads_domain }}/>
+  AllowOverride None
+  Options +Indexes
+  Require all granted
+</Directory>
+
+<VirtualHost *:80>
+  Include /etc/apache2/ffhb-downloads-common.conf
+</VirtualHost>
+
+<VirtualHost *:443>
+  Include /etc/apache2/ffhb-downloads-common.conf
+
+  SSLEngine on
+  SSLCertificateFile    /etc/ssl/certs/{{ downloads_domain }}.pem
+  SSLCertificateKeyFile /etc/ssl/private/{{ downloads_domain }}.key
+</VirtualHost>


### PR DESCRIPTION
In dieser Rolle fehlen noch die Info-Texte, die bei der Download-Seite über den Ordnerlisten angezeigt werden ("Hier werden Dateien des Freifunk Bremen bereitgestellt, die sich häufig ändern oder sehr groß sind." etc).
