### PR TITLE
wiki: restore Apache config for accessing Gollum server

### DIFF
--- a/roles/wiki/templates/wiki.conf
+++ b/roles/wiki/templates/wiki.conf
@@ -4,3 +4,28 @@
   AllowOverride AuthConfig FileInfo Indexes Limit Options=ExecCGI,Indexes,MultiViews,SymLinksIfOwnerMatch
   Options +SymLinksIfOwnerMatch -Includes
 </Directory>
+
+<Directory /var/www/{{ wiki_user }}/domains/{{ wiki_domain }}>
+  AllowOverride None
+  Options -Indexes
+
+  RewriteEngine On
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteRule ^(.*)$ http://127.0.0.1:{{ wiki_gollum_port }}/$1 [P,L]
+
+  SetEnvIfNoCase Request_URI ^/(create|edit|livepreview|delete|rename)/ require_auth=true
+
+  AuthType basic
+  AuthName "Dies ist ein Spamschutz. Benutzername: {{ wiki_http_username }}, Passwort: {{ wiki_http_password }}"
+  AuthUserFile /var/www/{{ wiki_user }}/domains/{{ wiki_domain }}/.htpasswd
+  ErrorDocument 401 "Die Benutzerabfrage dient lediglich der Spamvermeidung. Die Benutzerdaten lauten: Benutzername: {{ wiki_http_username }}, Passwort: {{ wiki_http_password }}"
+
+  Order Deny,Allow
+  Deny from All
+  Satisfy any
+  Allow from env=!require_auth
+  Require valid-user
+
+  # use "Home" as wiki start page
+  DirectoryIndex Home
+</Directory>


### PR DESCRIPTION
@mortzu : die Config ist jetzt nicht in einer .htaccess, sondern immer noch in /etc/apache2/ - deine Meinung dazu?
