### PR TITLE
letsencrypt: checkout a defined version of the letsencrypt.sh client

### DIFF
--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: Install letsencrypt client
-  git: repo=https://github.com/lukas2511/letsencrypt.sh.git dest=/opt/letsencrypt.sh
+  git: repo=https://github.com/lukas2511/letsencrypt.sh.git version=2f7da81f9b27a38734ea2db0b7256881d69739c8 dest=/opt/letsencrypt.sh


### PR DESCRIPTION
This should prevent accidental installation of a development snapshot of
the client.
The currently selected version is the one that was successfully used when
installing the last webserver.
