### PR TITLE
apache: disallow access to all directories and files starting with a dot

### DIFF
--- a/behave/webserver.feature
+++ b/behave/webserver.feature
@@ -108,3 +108,12 @@ Scenario: access to token/ directory is denied
     When I access http://status.bremen.freifunk.net/token/
     Then the status code will be 403
     And the page will contain "Forbidden"
+
+Scenario: access to .git/ directory is denied
+    When I access http://status.bremen.freifunk.net/.git/
+    Then the status code will be 403
+    And the page will contain "Forbidden"
+
+Scenario: access to .well-known directory is possible
+    When I access http://status.bremen.freifunk.net/.well-known/acme-challenge/
+    Then the status code will be 200

--- a/roles/apache/files/default-dir-options.conf
+++ b/roles/apache/files/default-dir-options.conf
@@ -3,3 +3,11 @@
   AllowOverride None
   Require all granted
 </Directory>
+
+# disallow access to all directories and files starting with a dot:
+<DirectoryMatch "^\.|\/\.">
+    Require all denied
+</DirectoryMatch>
+<FilesMatch "^\.">
+    Require all denied
+</FilesMatch>


### PR DESCRIPTION
There shouldn't be any cases where these paths should be accessible, and
in some cases they might actually contain sensitive information.

Meinungen? Ist das sinnvoll oder Overkill?
