### PR TITLE
Set ansible_managed to something static

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,13 +1,14 @@
 [defaults]
 
-inventory      = ./hosts
-roles_path     = ./roles
-filter_plugins = ./filter_plugins
-library        = ./library
-remote_user    = root
-nocows         = 1
+inventory       = ./hosts
+roles_path      = ./roles
+filter_plugins  = ./filter_plugins
+library         = ./library
+remote_user     = root
+nocows          = 1
+gathering       = smart
+ansible_managed = 'Ansible managed'
 vault_password_file = ./scripts/open.sh
-gathering      = smart
 
 [ssh_connection]
 pipelining     = true


### PR DESCRIPTION
Es nervt mich persönlich tierisch, dass bei jedem Run von Ansible der etckeeper hinterher bei lauter Dateien schreit, dass sie geändert wurden, bloß weil letztes Mal jemand anders ansible ausgeführt hat und deswegen jetzt `{{ ansible_managed }}` anders aussieht. Daher schlage ich vor, `ansible_managed` auf etwas statisches zu setzen was sich nicht abhängig vom PC, auf dem Ansible ausgeführt wird, ändert.
