### PR TITLE
Allow nodes to send respondd packets

### DIFF
--- a/roles/respondd/templates/firewall.sh
+++ b/roles/respondd/templates/firewall.sh
@@ -1,1 +1,3 @@
 ipt6 -A INPUT -i {{ main_bridge }} -p udp --dport 1001 -j ACCEPT
+ipt6 -A INPUT -i vpn-{{ site_code }}-legacy -p udp --dport 1001 -j ACCEPT
+ipt6 -A INPUT -i vpn-{{ site_code }} -p udp --dport 1001 -j ACCEPT


### PR DESCRIPTION
This will show the vpn name in node-status-page, again.

Diese Firewallregel, erlaubt es unseren Knoden auch die Namen und ein paar daten unsere Gateways in ihrer Status-Page anzuzeigen.
(so wie es bei vpn05 wieder und bei vpn06 noch ist)