### PR TITLE
use default route for freifunk subnet (babel, freifunk-service)

### DIFF
--- a/roles/exit-ipv6/templates/vpn-uplink6
+++ b/roles/exit-ipv6/templates/vpn-uplink6
@@ -8,9 +8,6 @@ iface vpn-uplink6 inet6 static
 	# add default route
 	post-up ip -6 route add default via {{ ipv6_uplink_own_gateway.address }} dev $IFACE table default-freifunk
 	pre-down ip -6 route del default via {{ ipv6_uplink_own_gateway.address }} dev $IFACE table default-freifunk
-	# add route to services hosts
-	post-up ip -6 route add 2a06:8782:ff00::/64 via {{ ipv6_uplink_own_gateway.address }} dev $IFACE table default-freifunk
-	pre-down ip -6 route del 2a06:8782:ff00::/64 via {{ ipv6_uplink_own_gateway.address }} dev $IFACE table default-freifunk
 	# choose the correct default route
 	post-up ip -6 rule add from {{ batman_ipv6_global.address }} table default-freifunk priority 16385
 	post-down ip -6 rule del from {{ batman_ipv6_global.address }} table default-freifunk priority 16385

--- a/roles/router-bird/templates/bird6.conf
+++ b/roles/router-bird/templates/bird6.conf
@@ -47,7 +47,7 @@ protocol kernel k_freifunk {
     kernel table 252;
     scan time 10;
     import none;
-    export where net != ::/0;
+    export where net != ::/0 && net != 2a06:8782::/32;
 };
 
 # this pseudo-protocol watches all interface up/down events


### PR DESCRIPTION
fix #86 