### PR TITLE
webserver: add "Restart=always" for gollum

### DIFF
--- a/roles/wiki/templates/gollum.service
+++ b/roles/wiki/templates/gollum.service
@@ -5,6 +5,8 @@ Description=Gollum git based wiki
 WorkingDirectory=%h/.opt/gollum
 SyslogIdentifier=%p
 ExecStart=/usr/bin/bundle exec bin/gollum --port {{ wiki_gollum_port }} --host 127.0.0.1 --adapter rugged --css --h1-title --ref wiki "%h/.var/gollum-envs/ff-bremen"
+Restart=always
+RestartSec=5
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
The Gollum wiki process ("bundle") is occasionally killed by OOM-killer:

[1361188.923187] Out of memory: Kill process 652 (bundle) score 327 or sacrifice child
[1361188.927720] Killed process 652 (bundle) total-vm:1931052kB, anon-rss:1296988kB, file-rss:0kB, shmem-rss:0kB

Maybe it has a memory leak. I didn't find quick way to solve that, so now
the process is at least restarted automatically if it falls over.
This is the same change that was already made for tessera.service.